### PR TITLE
Fix version of bitcoinj-core to 0.13.5

### DIFF
--- a/stratum-protocol/pom.xml
+++ b/stratum-protocol/pom.xml
@@ -139,7 +139,7 @@
         <dependency>
             <groupId>org.bitcoinj</groupId>
             <artifactId>bitcoinj-core</artifactId>
-            <version>0.13-SNAPSHOT</version>
+            <version>0.13.5</version>
         </dependency>
         <dependency>
             <groupId>smartwallet</groupId>


### PR DESCRIPTION
This is just a convenient version fix because of one of the dependency is unable to build properly with bitcoinj-core:0.14-SNAPSHOT

dependency affected: java-smartcolors
fixed in separate pull request
